### PR TITLE
Fixed TLS requirement in function DownloadParsecServiceManager()

### DIFF
--- a/PostInstall/PostInstall.ps1
+++ b/PostInstall/PostInstall.ps1
@@ -486,6 +486,7 @@ sc.exe Start 'Parsec' | Out-Null
 }
 
 Function DownloadParsecServiceManager {
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 (New-Object System.Net.WebClient).DownloadFile("https://github.com/jamesstringerparsec/Parsec-Service-Manager/raw/master/ParsecServiceManager.exe", "$ENV:UserProfile\Desktop\ParsecServiceManager.exe") | Unblock-File
 }
 


### PR DESCRIPTION
For some reason just the call for ParsecServiceManager.exe in line 489 was failing to download, I tried running it manually with the ServicePointManager set. I've added one line before 489 to set this to TLS1.2 preference.