### PR TITLE
Fix GoogleGRID url in Clear-Proxy.ps1

### DIFF
--- a/PreInstall/Clear-Proxy.ps1
+++ b/PreInstall/Clear-Proxy.ps1
@@ -83,7 +83,7 @@ if (($gpu.supported -eq "No") -eq $true) {"Sorry, this GPU (" + $gpu.name + ") i
 Exit
 }
 Elseif (($gpu.Supported -eq "UnOfficial") -eq $true) {
-if ($url.GoogleGRID -eq $null) {$URL.GoogleGRID = Invoke-WebRequest -uri https://cloud.google.com/compute/docs/gpus/add-gpus#installing_grid_drivers_for_virtual_workstations -UseBasicParsing} Else {}
+if ($url.GoogleGRID -eq $null) {$URL.GoogleGRID = Invoke-WebRequest -uri https://cloud.google.com/compute/docs/gpus/install-grid-drivers -UseBasicParsing} Else {}
 $($($URL.GoogleGRID).Links | Where-Object href -like *server2016_64bit_international.exe*).outerHTML.Split('/')[6].split('_')[0]
 }
 Else { 

--- a/PreInstall/Clear-Proxy.ps1
+++ b/PreInstall/Clear-Proxy.ps1
@@ -84,7 +84,7 @@ Exit
 }
 Elseif (($gpu.Supported -eq "UnOfficial") -eq $true) {
 if ($url.GoogleGRID -eq $null) {$URL.GoogleGRID = Invoke-WebRequest -uri https://cloud.google.com/compute/docs/gpus/install-grid-drivers -UseBasicParsing} Else {}
-$($($URL.GoogleGRID).Links | Where-Object href -like *server2016_64bit_international.exe*).outerHTML.Split('/')[6].split('_')[0]
+$($($URL.GoogleGRID).Links | Where-Object href -like *server2016_server2019_64bit_international.exe*).outerHTML.Split('/')[6].split('_')[0]
 }
 Else { 
 $gpu.URL = "https://www.nvidia.com/Download/processFind.aspx?psid=" + $gpu.psid + "&pfid=" + $gpu.pfid + "&osid=" + $gpu.osid + "&lid=1&whql=1&lang=en-us&ctk=0"


### PR DESCRIPTION
I found this while trying to debug why my EC2 instances launched from snapshots are always stuck at 1366x768 even though the machine the snapshots were created from works just fine. Didn't fix my problem, but maybe this will fix someone else's.

Two changes:
* URL of Google Cloud support page has changed
* There are now separate links for Windows Server 2016 and 2019, but the 2019 link looks (?) like it should work for both based on the file name