### PR TITLE
Fix how PromptPasswordUpdateGPU is passed to functions

### DIFF
--- a/PostInstall/PostInstall.ps1
+++ b/PostInstall/PostInstall.ps1
@@ -881,7 +881,7 @@ Write-Host -foregroundcolor red "
                     Google T4  VW    (Tesla T4 Virtual Workstation)
 
 "   
-PromptUserAutoLogon -PromptPasswordUpdateGPU PromptPasswordUpdateGPU
+PromptUserAutoLogon -PromptPasswordUpdateGPU:$PromptPasswordUpdateGPU
 setupEnvironment
 addRegItems
 create-directories
@@ -911,7 +911,7 @@ disable-devices
 clean-up
 clean-up-recent
 provider-specific
-StartGPUUpdate -PromptPasswordUpdateGPU PromptPasswordUpdateGPU
+StartGPUUpdate -PromptPasswordUpdateGPU:$PromptPasswordUpdateGPU
 Write-Host "1. Open Parsec and sign in" -ForegroundColor black -BackgroundColor Green 
 Write-Host "2. Use GPU Updater to update your GPU Drivers!" -ForegroundColor black -BackgroundColor Green 
 Write-host "DONE!" -ForegroundColor black -BackgroundColor Green 


### PR DESCRIPTION
Hello,

I have configured a user data script on my EC2 instance to automatically configure the `DefaultUserName` and `DefaultPassword` registry keys. This works until I execute Parsec-Cloud-Preparation-Tool.

I took a peek and found that the `DefaultUserName` was set to an empty string just after it was set with the username. I think is an error.